### PR TITLE
Add security review, apply dependency overrides, and replace git-repo-name with git config lookup

### DIFF
--- a/SECURITY_REVIEW_2026-04-22.md
+++ b/SECURITY_REVIEW_2026-04-22.md
@@ -1,0 +1,54 @@
+# Dependency Vulnerability Review (2026-04-22)
+
+This review validates the vulnerable packages reported in `package-lock.json` and maps each one to the currently resolved version in this repository.
+
+## Method used
+
+- Enumerated package versions from `package-lock.json` using a Node.js script.
+- Cross-checked dependency paths with `npm ls <package> --all`.
+- Attempted `npm audit --json`, but the environment returned `403 Forbidden` for the advisory endpoint.
+
+## Findings
+
+| Dependency | Version(s) currently resolved | Reported safe target | Status |
+|---|---:|---:|---|
+| loader-utils | 0.2.17, 2.0.4, 3.3.1 | `~1.4.1` | **Needs review**: legacy `0.2.17` present via `postcss-icss-selectors -> generic-names`. |
+| json5 | 0.5.1, 2.2.3 | `~1.0.2` | **Needs review**: legacy `0.5.1` present via `generic-names -> loader-utils@0.2.17`. |
+| postcss | 6.0.23, 7.0.39, 8.5.4 | `~8.4.31` | **Version appears above target** for main path (`8.5.4`), but older majors still present for older plugins. |
+| parse-git-config | 3.0.0 | (not provided) | **Needs remediation**: comes from `git-repo-name -> remote-origin-url`. |
+| on-headers | 1.0.2 | `~1.1.0` | **Needs remediation** (`webpack-dev-server -> compression`). |
+| min-document | 2.19.0 | `~2.19.1` | **Needs remediation** (`react-hot-loader -> global`). |
+| @messageformat/runtime | 3.0.1 | `~3.0.2` | **Needs remediation** (`prettier-eslint-cli -> @messageformat/core`). |
+| js-yaml | 3.14.1, 4.1.0 | `~4.1.1` | **Needs remediation** for `3.14.1` path and patch bump for v4 path. |
+| glob | 7.2.3, 10.4.5 | `~10.5.0` | **Needs review**: vulnerable report may target v10 path; patch bump recommended. |
+| node-forge | 1.3.1 | `~1.3.2` | **Needs remediation** (`webpack-dev-server -> selfsigned`). |
+| qs | 6.13.0 | `~6.14.1` | **Needs remediation** (`express`). |
+| lodash | 4.17.21 | `~4.17.23` | **Needs remediation**. |
+| webpack | 5.99.9 | `~5.104.1` | **Needs remediation** (direct devDependency bump). |
+| minimatch | 3.0.8, 3.1.2, 9.x | `~3.1.3` | **Needs remediation** for v3 paths. |
+| serialize-javascript | 6.0.2 | `~7.0.3` | **Needs remediation** (`webpack -> terser-webpack-plugin`). |
+| svgo | 3.3.2 | `~3.3.3` | **Needs remediation**. |
+| socket.io-parser | 4.2.4 | `~4.2.6` | **Needs remediation** (`socket.io-client`). |
+| flatted | 3.3.3 | `~3.4.2` | **Needs remediation**. |
+| picomatch | 2.3.1 | `~2.3.2` | **Needs remediation**. |
+| follow-redirects | 1.15.9 | `~1.16.0` | **Needs remediation** (`http-proxy`). |
+
+## Blockers encountered while remediating
+
+1. `npm audit` is currently blocked by registry policy:
+   - `403 Forbidden - POST https://registry.npmjs.org/-/npm/v1/security/advisories/bulk`
+2. Attempting to install updated versions is blocked in this environment for some packages:
+   - `403 Forbidden - GET https://registry.npmjs.org/webpack`
+
+## Recommended remediation strategy
+
+1. **Unblock registry access for installs and audit**, then run:
+   - `npm audit --json`
+   - `npm audit fix`
+   - targeted updates for unresolved transitive dependencies.
+2. Add `overrides` in `package.json` for transitive-only vulnerable packages that are not updated by parent package bumps.
+3. Replace or remove stale packages introducing old transitive chains (notably `git-repo-name` path pulling `parse-git-config@3.0.0` and `postcss-icss-selectors` path pulling `loader-utils@0.2.17`/`json5@0.5.1`).
+4. Re-run full checks:
+   - `npm ls` for each affected package
+   - `npm audit --production --json`
+   - project lint/tests/build.

--- a/package.json
+++ b/package.json
@@ -61,7 +61,6 @@
         "favicons-webpack-plugin": "^6.0.1",
         "file-loader": "~6.2.0",
         "gh-pages": "~6.3.0",
-        "git-repo-name": "^1.0.1",
         "html-webpack-plugin": "^5.6.3",
         "identity-obj-proxy": "^3.0.0",
         "jest": "~29.7.0",
@@ -86,7 +85,7 @@
         "style-loader": "^4.0.0",
         "stylelint": "~16.8.0",
         "url-loader": "^4.1.1",
-        "webpack": "^5.99.9",
+        "webpack": "^5.104.1",
         "webpack-bundle-analyzer": "^4.10.2",
         "webpack-cli": "~6.0.1",
         "webpack-dev-server": "^5.2.2",
@@ -111,5 +110,25 @@
         },
         "exec": "webpack-dev-server --config=./webpack/webpack.config.babel.js --env development",
         "ext": "js json"
+    },
+    "overrides": {
+        "@messageformat/runtime": "3.0.2",
+        "flatted": "3.4.2",
+        "follow-redirects": "1.16.0",
+        "glob": "10.5.0",
+        "js-yaml": "4.1.1",
+        "json5": "1.0.2",
+        "loader-utils": "1.4.1",
+        "lodash": "4.17.23",
+        "min-document": "2.19.1",
+        "minimatch": "3.1.3",
+        "node-forge": "1.3.2",
+        "on-headers": "1.1.0",
+        "picomatch": "2.3.2",
+        "postcss": "8.4.31",
+        "qs": "6.14.1",
+        "serialize-javascript": "7.0.3",
+        "socket.io-parser": "4.2.6",
+        "svgo": "3.3.3"
     }
 }

--- a/webpack/configurations/common.js
+++ b/webpack/configurations/common.js
@@ -1,8 +1,8 @@
 // webpack/configurations/common.js
 
 // Core
-import getRepositoryName from 'git-repo-name';
 import chalk from 'chalk';
+import { execSync } from 'node:child_process';
 
 // Paths
 import { source, build } from '../paths.js';
@@ -27,7 +27,13 @@ export const generateCommonConfiguration = () => {
     let REPOSITORY_NAME = '';
 
     try {
-        REPOSITORY_NAME = getRepositoryName.sync();
+        const remoteUrl = execSync('git config --get remote.origin.url', {
+            encoding: 'utf8',
+            stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim();
+        const [, repositoryName = ''] = remoteUrl.match(/([^/]+?)(?:\.git)?$/) || [];
+
+        REPOSITORY_NAME = repositoryName;
     } catch (error) {
         console.log(
             chalk.whiteBright.bgRed.bold(`


### PR DESCRIPTION
### Motivation

- Remediate and document known transitive dependency vulnerabilities reported against `package-lock.json` and ensure the project can pin safe package versions via `overrides` in `package.json`.
- Remove the `git-repo-name` dependency and replace it with a minimal builtin solution to avoid pulling legacy transitive packages.

### Description

- Added `SECURITY_REVIEW_2026-04-22.md` documenting the dependency vulnerability findings, remediation recommendations, and blockers encountered during auditing.
- Updated `package.json` to remove `git-repo-name`, bump `webpack` to `^5.104.1`, and add an `overrides` section pinning numerous transitive packages (including `loader-utils`, `json5`, `postcss`, `lodash`, `js-yaml`, and others) to safer versions.
- Modified `webpack/configurations/common.js` to remove the `git-repo-name` import and instead use `execSync('git config --get remote.origin.url')` to derive the repository name from the local git config.

### Testing

- Attempted `npm audit --json` during the review but it failed due to registry policy with a `403 Forbidden` response, so automated audit remediation could not be completed in this environment.
- No other automated tests were executed as part of this rollout due to the registry access blockers, and CI/build verification should be run after unblocking the registry and installing dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e870139b888331be4ab651c7de3965)